### PR TITLE
Configure libsolid-rs to build for android

### DIFF
--- a/libsolid-rs/Cargo.toml
+++ b/libsolid-rs/Cargo.toml
@@ -19,6 +19,9 @@ serde = "1.0"
 serde_json = "1.0"
 openssl = { version = "0.10", features = ["vendored"] }
 
+[lib]
+crate-type = ["dylib"]
+
 [dev-dependencies]
 mktemp = "0.4"
 reqwest = { version = "0.10.0-alpha.2", features = [ "blocking", "cookies", "tls" ] }

--- a/libsolid-rs/Cargo.toml
+++ b/libsolid-rs/Cargo.toml
@@ -17,6 +17,7 @@ actix-server = "1.0.0-alpha.2"
 url = "2.1"
 serde = "1.0"
 serde_json = "1.0"
+openssl = { version = "0.10", features = ["vendored"] }
 
 [dev-dependencies]
 mktemp = "0.4"


### PR DESCRIPTION
After trying to build `libsolid-rs` for Android `armv7`, `i686` and `x86_64` without success, I found the only way is to include `openssl` as a dependency with the `vendored` feature. See this [issue](https://github.com/rust-windowing/android-rs-glue/issues/193#issuecomment-435619595).

And, to generate a dynamic library that can be used by Android's `jniLibs` the `crate-type` needs to be specified as `dylib`.